### PR TITLE
Fix decoding of custom types with no fields

### DIFF
--- a/src/ffi.erl
+++ b/src/ffi.erl
@@ -19,6 +19,14 @@ decode_tuple(X) ->
 
 decode_custom_type(X) ->
     case X of
+        % Variants with no fields are encoded as a single atom named as the variant.
+        Atom when is_atom(Atom) ->
+            case inspect_maybe_gleam_atom(erlang:atom_to_binary(Atom), none, <<>>) of
+                {ok, AtomName} -> {ok, {t_custom, AtomName, []}};
+                {error, nil} -> decode_error("CustomType", X)
+            end;
+        % Variants with fields are encoded as tuples where the first items is an
+        % atom with the variant's name.
         Tuple when is_tuple(Tuple) ->
             case tuple_to_list(Tuple) of
                 [Atom | Elements] when is_atom(Atom) ->

--- a/test/pprint_test.gleam
+++ b/test/pprint_test.gleam
@@ -1,14 +1,26 @@
 import gleam/dict
+import gleam/dynamic
 import gleeunit
+import gleeunit/should
 import birdie
 import pprint
+import pprint/decoder
 
 type Foo {
   Foo(Int, bar: String, baz: String)
+  Wibble
 }
 
 pub fn main() {
   gleeunit.main()
+}
+
+// https://github.com/MystPi/pprint/issues/2
+pub fn custom_type_with_no_fields_decoding_test() {
+  Wibble
+  |> dynamic.from
+  |> decoder.classify
+  |> should.equal(decoder.TCustom("Wibble", []))
 }
 
 pub fn pretty_list_test() {


### PR DESCRIPTION
The decoder for custom types on the Erlang side didn't take into account variants with no fields: variants with fields are encoded as a tuple `{variant_name, field_1, ..., field_n}`; however, variants with no fields are encoded as a single atom: `variant_name`.

In my previous implementation I only checked `is_tuple` and didn't take into account that even a single atom could be a valid variant.
I've added the missing case and a regression test!

This PR closes #2 